### PR TITLE
made the try now button to not go down when letters are popped

### DIFF
--- a/assets/css/landing_page.css
+++ b/assets/css/landing_page.css
@@ -192,9 +192,10 @@ h2{
 .colorflipper2{
 	background-color:plum;height:200px;
 }
-h4{
+.auto-write-target-class{
 	padding-left: 60px;
-	padding-top: 60px;
+	bottom: 50%;
+  position:absolute;
 	color: ghostwhite;
 }
 p{

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
           <!--Start of auto-write-text-->
           <img class="card-img-top" src="assets/Images/auto-write.jpg" alt="Card auto-write">
           <div class="auto-write">
-            <h4 id="auto-write-target"></h4>
+            <h4 style="color: crimson;" id="auto-write-target" class="auto-write-target-class"></h4>
           </div>
           <!--End of auto write text-->
           <div class="card-body" id="auto-write-text">


### PR DESCRIPTION
#250 
changed the landing page CSS and the index file, so that the letters don't take extra space on the card to pop up, instead, they are popped on the image itself.
Before
https://user-images.githubusercontent.com/73388412/156584995-e5115ac7-357d-4cc0-8761-42471913de3b.png
after
![image](https://user-images.githubusercontent.com/73388412/156832806-873d21f7-a665-4626-913f-50f2f5118dcf.png)
✅ I agree to follow this project's [Code of Conduct](https://github.com/ZeroOctave/ZeroOctave-Javascript-Projects/blob/main/CODE_OF_CONDUCT.md).
✅ I checked the [current issues](https://github.com/ZeroOctave/ZeroOctave-Javascript-Projects/issues) for duplicate problems.
✅ I have gone through project [README](https://github.com/ZeroOctave/ZeroOctave-Javascript-Projects/blob/main/README.md).
