### PR TITLE
drum_kit file updated, keypress replaced with keydown

### DIFF
--- a/assets/Js/drum_kit.js
+++ b/assets/Js/drum_kit.js
@@ -1,12 +1,12 @@
 for (var i = 0; i < document.querySelectorAll(".drum").length; i++) {
-    document.querySelectorAll(".drum")[i].addEventListener("click", function() {
+    document.querySelectorAll("button")[i].addEventListener("click", function() {
       var sound = this.innerHTML;
       makeSound(sound);
       buttonAnimation(sound);
     });
   }
   
-  document.addEventListener("keypress", function(event) {
+  document.addEventListener("keydown", function(event) {
     makeSound(event.key);
     buttonAnimation(event.key);
   });


### PR DESCRIPTION
### 🛠️ Fixes Issue #846 

 ### Closes #846 

### 👨‍💻 Changes proposed

"Keypress" is replaced with "keydown" in assets\Js\drum_kit.js for key press event listener.

### ✅ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [ ] My code doesn't break any part of the project (Zero Octave-Javascript-Projects).
- [ ] This PR does not contain plagiarized content.
- [ ] My Addition/Changes works properly and matches the overall repo pattern.
- [ ] The title of my pull request is a short description of the requested changes.

