### PR TITLE
Incorrect positioning of BMI chart in BMI calculator

### DIFF
--- a/Public/bmi-calculator.html
+++ b/Public/bmi-calculator.html
@@ -58,7 +58,7 @@
                      <18.5</td>
                </tr>
                <tr>
-                  <td>Noraml</td>
+                  <td>Normal</td>
                   <td>18.5 to 24.9</td>
                </tr>
                <tr>

--- a/assets/css/bmi-calculator.css
+++ b/assets/css/bmi-calculator.css
@@ -6,11 +6,9 @@
 }
 
 .background_image{
- passwordvalidator
     background-image: url("../Images/pexels-nataliya-vaitkevich-6942085.jpg");
 
     background-image: url("../Images/background-fitness-bmi.jpg");
- main
     background-repeat: no-repeat;
     background-size: 100% 100%;
     height:100vh;
@@ -118,14 +116,15 @@ button:hover {
 }
 
 .new-addition {
+    left:950px;
+    top:130px;
     background-color: cornsilk;
     width: 20%;
     height: auto;
     border: black 3px;
     margin: 5px;
     padding: 25px;
-    position: relative;
-    top: -20px;
+    position: fixed;
     border-radius: 4px;
     word-spacing: 12px;
 


### PR DESCRIPTION
<!-- Remove the sections which are not applicable -->

### 👨‍💻 Changes proposed
In the BMI calculator page, the BMI chart earlier covered the calculate and reset buttons
<img width="960" alt="image" src="https://user-images.githubusercontent.com/97738900/191110159-c2a6c65b-e5dd-457b-ab73-bfae642272f6.png">

Also, there is a spelling error of the word 'normal'

<!-- List all the proposed changes in your PR -->
I have changed the position of the BMI chart and shifted it to the right of the page.
Also, I have corrected the spelling of the word 'normal'
<img width="960" alt="image" src="https://user-images.githubusercontent.com/97738900/191110471-93a90684-dded-4e55-b40d-e96f691d2d09.png">


