### PR TITLE
input type name property fixed

### DIFF
--- a/Public/happy_hacktober/happyhactober.html
+++ b/Public/happy_hacktober/happyhactober.html
@@ -38,11 +38,11 @@
         <div style="font-size:28px">
             <span class="info">Gender</span>&nbsp;
             
-            <input type="radio" name="male" value="Male">Male</input>
+            <input type="radio" name="gender" value="Male">Male</input>
             
-            <input type="radio" name="Female" value="Female">Female</input>
+            <input type="radio" name="gender" value="Female">Female</input>
             
-            <input type="radio" name="other" value="other">Other</input>
+            <input type="radio" name="gender" value="other">Other</input>
         </div>
         <div>
             


### PR DESCRIPTION
In the input section of gender, where the input type is radio, only one of the options must be selected at once but it was selecting all of them. I corrected that bug.

### ✅ Check List (Check all the applicable boxes) <!-- Follow the below conventions to check the box -->

- [x] My code doesn't break any part of the project (Zero Octave-Javascript-Projects).
- [x] This PR does not contain plagiarized content.
- [x] My Addition/Changes works properly and matches the overall repo pattern.
- [x] The title of my pull request is a short description of the requested changes.

### 📄 Note to reviewers

<!-- Add notes to reviewers if applicable -->

### 📷 Screenshots

<!-- Add screenshots -->

older:
![older_hack](https://user-images.githubusercontent.com/106550459/197396771-fa7f4f30-7ab6-4da9-ab77-36e4e177d706.png)

newer:
![newer_hack](https://user-images.githubusercontent.com/106550459/197396784-1aae92da-b4e0-425b-9903-81465b5d1728.png)

