### PR TITLE
Removed Long Conditional (wieghtConverter)

### DIFF
--- a/assets/Js/weight_conv.js
+++ b/assets/Js/weight_conv.js
@@ -73,7 +73,7 @@ function reset() {
 
     //  this contribution is done .....
       document.getElementById('output').value="";
-      finalOutput.innerHTML="";git
+      finalOutput.innerHTML="";
       document.getElementById('weightOutput').innerHTML = "";
       weight="";
       

--- a/assets/Js/weight_conv.js
+++ b/assets/Js/weight_conv.js
@@ -28,95 +28,35 @@ function getsecOpt(e) {
     weightConverter();
 }
 
+/**
+ * Refactored weightConverter using a Lookup Table
+ */
 function weightConverter() {
     const finalOutput = document.querySelector('#finalOutput');
 
-    if (firOpt == "Pounds" && secOpt == "Grams") {
-        finalOutput.innerHTML = weight * 453.59237;
-    } else if (firOpt == "Pounds" && secOpt == "Kilograms") {
-        finalOutput.innerHTML = weight * 0.453592;
-    } else if (firOpt == "Pounds" && secOpt == "Milligrams") {
-        finalOutput.innerHTML = weight * 453592.0000001679;
-    } else if (firOpt == "Pounds" && secOpt == "Micrograms") {
-        finalOutput.innerHTML = weight * 453591999.86863;
-    } else if (firOpt == "Pounds" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 0.0004999995920000043512;
-    } else if (firOpt == "Pounds" && secOpt == "Ounces") {
-        finalOutput.innerHTML = weight * 15.999986944000138323;
-    }
-    //Validates for grams
-    else if (firOpt == "Grams" && secOpt == "Pounds") {
-        finalOutput.innerHTML = weight * 0.00220462;
-    } else if (firOpt == "Grams" && secOpt == "Kilograms") {
-        finalOutput.innerHTML = weight * 0.001;
-    } else if (firOpt == "Grams" && secOpt == "Milligrams") {
-        finalOutput.innerHTML = weight * 1000;
-    } else if (firOpt == "Grams" && secOpt == "Micrograms") {
-        finalOutput.innerHTML = weight * 1e+6;
-    } else if (firOpt == "Grams" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 1.1023e-6;
-    } else if (firOpt == "Grams" && secOpt == "Ounces") {
-        finalOutput.innerHTML = weight * 0.035274;
-    }
-    //Validates for Kilograms
-    else if (firOpt == "Kilograms" && secOpt == "Grams") {
-        finalOutput.innerHTML = weight * 1000;
-    } else if (firOpt == "Kilograms" && secOpt == "Pounds") {
-        finalOutput.innerHTML = weight * 2.20462;
-    } else if (firOpt == "Kilograms" && secOpt == "Milligrams") {
-        finalOutput.innerHTML = weight * 1e+6;
-    } else if (firOpt == "Kilograms" && secOpt == "Micrograms") {
-        finalOutput.innerHTML = weight * 1e+9;
-    } else if (firOpt == "Kilograms" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 0.00110231;
-    } else if (firOpt == "Kilograms" && secOpt == "Ounces") {
-        finalOutput.innerHTML = weight * 35.274;
-    }
-    //Validates for Milligram
-    else if (firOpt == "Milligrams" && secOpt == "Pounds") {
-        finalOutput.innerHTML = weight * 2.2046e-6;
-    } else if (firOpt == "Milligrams" && secOpt == "Kilograms") {
-        finalOutput.innerHTML = weight * 1e-6;
-    } else if (firOpt == "Milligrams" && secOpt == "Grams") {
-        finalOutput.innerHTML = weight * 0.001;
-    } else if (firOpt == "Milligrams" && secOpt == "Micrograms") {
-        finalOutput.innerHTML = weight * 1000;
-    } else if (firOpt == "Milligrams" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 1.1023e-9;
-    } else if (firOpt == "Milligrams" && secOpt == "Ounces") {
-        finalOutput.innerHTML = weight * 3.5274e-5;
-    }
-    //Validates for Microgram
-    else if (firOpt == "Micrograms" && secOpt == "Pounds") {
-        finalOutput.innerHTML = weight * 2.2046e-9;
-    } else if (firOpt == "Micrograms" && secOpt == "Kilograms") {
-        finalOutput.innerHTML = weight * 1e-9;
-    } else if (firOpt == "Micrograms" && secOpt == "Milligrams") {
-        finalOutput.innerHTML = weight * 0.001;
-    } else if (firOpt == "Micrograms" && secOpt == "Grams") {
-        finalOutput.innerHTML = weight * 1e-6;
-    } else if (firOpt == "Micrograms" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 1.1023e-12;
-    } else if (firOpt == "Micrograms" && secOpt == "Ounces") {
-        finalOutput.innerHTML = weight * 3.5274e-8;
-    }
-    //Validates for Ounce
-    else if (firOpt == "Ounces" && secOpt == "Pounds") {
-        finalOutput.innerHTML = weight * 0.0625;
-    } else if (firOpt == "Ounces" && secOpt == "Kilograms") {
-        finalOutput.innerHTML = weight * 0.0283495;
-    } else if (firOpt == "Ounces" && secOpt == "Milligrams") {
-        finalOutput.innerHTML = weight * 28349.5;
-    } else if (firOpt == "Ounces" && secOpt == "Micrograms") {
-        finalOutput.innerHTML = weight * 2.835e+7;
-    } else if (firOpt == "Ounces" && secOpt == "US Tons") {
-        finalOutput.innerHTML = weight * 3.125e-5;
-    } else if (firOpt == "Ounces" && secOpt == "Grams") {
-        finalOutput.innerHTML = weight * 28.3495;
-    }
-    //Validates if first option is the same as second option
-    else {
-        finalOutput.innerHTML = weight;
+    //Define conversion rates relative to a base unit (Grams)
+    const conversionRates = {
+        "Grams": 1,
+        "Kilograms": 1000,
+        "Milligrams": 0.001,
+        "Micrograms": 0.000001,
+        "Pounds": 453.59237,
+        "Ounces": 28.34952,
+        "US Tons": 907184.74
+    };
+
+    // Check if units exist in our table and weight is provided
+    if (conversionRates[firOpt] && conversionRates[secOpt] && weight !== undefined) {
+
+        //Convert input to Grams, then Grams to target unit
+        const weightInGrams = weight * conversionRates[firOpt];
+        const convertedValue = weightInGrams / conversionRates[secOpt];
+
+
+        finalOutput.innerHTML = convertedValue;
+    } else {
+        // Fallback
+        finalOutput.innerHTML = weight || "";
     }
 }
 
@@ -133,7 +73,7 @@ function reset() {
 
     //  this contribution is done .....
       document.getElementById('output').value="";
-      finalOutput.innerHTML="";
+      finalOutput.innerHTML="";git
       document.getElementById('weightOutput').innerHTML = "";
       weight="";
       


### PR DESCRIPTION
### 🛠️ Fixes Issue (1097)

Closes #1097 

### 👨‍💻 Changes proposed

Refactored weightConverter function: Eliminated a massive if-else block to solve the "Long Conditional"

Implemented Lookup Table Pattern: Introduced a conversionRates object that stores all units relative to a base unit (Grams).

Simplified Logic: Reduced the conversion math to a single formula: (value * fromRate) / toRate.

### ✅ Check List 

- [x ] You have linked this PR to the correct issue.
- [ x] My code doesn't break any part of the project (Zero Octave-Javascript-Projects).
- [x ] This PR does not contain plagiarized content.
- [ x] My Addition/Changes works properly and matches the overall repo pattern.
- [x ] The title of my pull request is a short description of the requested changes.

### 📄 Note to reviewers

 Refactoring improved complexity of the project, the original conversion factors are preserved in the new conversionRates object. The UI logic remains the same.